### PR TITLE
Mediciones: indice { stationId, date } y downsampling configurable (bucketMinutes)

### DIFF
--- a/scripts/downsample-measurements.js
+++ b/scripts/downsample-measurements.js
@@ -1,0 +1,79 @@
+/*
+ * Downsampling de station_measurements: conserva 1 medida por bucket de N minutos
+ * (por estacion) y borra el resto. Pensado para limpiar datos historicos densos.
+ *
+ * SEGURIDAD:
+ *   - Por defecto DRY_RUN=true: solo informa, NO borra.
+ *   - Haz SIEMPRE un mongodump antes de ejecutarlo con DRY_RUN=false.
+ *   - Procesa dia a dia para no cargar millones de documentos en memoria.
+ *
+ * Uso:
+ *   node scripts/downsample-measurements.js                 # simulacion (no borra)
+ *   DRY_RUN=false node scripts/downsample-measurements.js   # borra de verdad
+ *
+ * Variables opcionales:
+ *   MONGO_URI    (default: mongodb://127.0.0.1:27017/?directConnection=true)
+ *   DB_NAME      (default: mongo-kairos)
+ *   BUCKET_MIN   (default: 5)      minutos por bucket a conservar
+ *   STATION_ID   (default: todas)  limitar a una estacion concreta
+ */
+const { MongoClient } = require('mongodb');
+
+const DRY_RUN = process.env.DRY_RUN !== 'false';
+const URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/?directConnection=true';
+const DB_NAME = process.env.DB_NAME || 'mongo-kairos';
+const BUCKET_MS = (parseInt(process.env.BUCKET_MIN || '5', 10)) * 60 * 1000;
+const STATION_ID = process.env.STATION_ID || null;
+
+(async () => {
+  const client = new MongoClient(URI);
+  await client.connect();
+  const col = client.db(DB_NAME).collection('station_measurements');
+
+  console.log(`Modo: ${DRY_RUN ? 'DRY-RUN (no borra)' : 'BORRADO REAL'} | bucket=${BUCKET_MS / 60000} min` +
+              (STATION_ID ? ` | estacion=${STATION_ID}` : ' | todas las estaciones'));
+
+  const match = STATION_ID ? { stationId: STATION_ID } : {};
+  const range = await col.aggregate([
+    { $match: match },
+    { $group: { _id: null, min: { $min: '$date' }, max: { $max: '$date' } } },
+  ]).toArray();
+  if (!range.length) { console.log('Sin datos.'); await client.close(); return; }
+
+  const start = new Date(range[0].min); start.setUTCHours(0, 0, 0, 0);
+  const end = new Date(range[0].max);
+  let totalKept = 0, totalDeleted = 0;
+
+  for (let day = new Date(start); day < end; day.setUTCDate(day.getUTCDate() + 1)) {
+    const dayStart = new Date(day);
+    const dayEnd = new Date(day); dayEnd.setUTCDate(dayEnd.getUTCDate() + 1);
+
+    const docs = await col.find(
+      { ...match, date: { $gte: dayStart, $lt: dayEnd } },
+      { projection: { _id: 1, date: 1, stationId: 1 }, sort: { date: 1 } },
+    ).toArray();
+    if (!docs.length) continue;
+
+    const seen = new Set();
+    const toDelete = [];
+    for (const d of docs) {
+      const key = d.stationId + '|' + Math.floor(new Date(d.date).getTime() / BUCKET_MS);
+      if (seen.has(key)) toDelete.push(d._id); // ya hay uno en este bucket -> sobra
+      else seen.add(key);
+    }
+
+    totalKept += seen.size;
+    totalDeleted += toDelete.length;
+
+    if (!DRY_RUN && toDelete.length) {
+      // borrar por lotes para no mandar arrays gigantes
+      for (let i = 0; i < toDelete.length; i += 5000) {
+        await col.deleteMany({ _id: { $in: toDelete.slice(i, i + 5000) } });
+      }
+    }
+    console.log(`  ${dayStart.toISOString().slice(0, 10)}: ${docs.length} -> conservar ${seen.size}, borrar ${toDelete.length}`);
+  }
+
+  console.log(`\nTOTAL: conservar ${totalKept}, borrar ${totalDeleted}` + (DRY_RUN ? '  (DRY-RUN: no se borro nada)' : '  (BORRADO REALIZADO)'));
+  await client.close();
+})().catch(e => { console.error('❌', e); process.exit(1); });

--- a/src/stations/controllers/stations.controller.ts
+++ b/src/stations/controllers/stations.controller.ts
@@ -1,5 +1,5 @@
 import { StationResponseDto } from './../dto/station-response.dto';
-import { DateQueryDto } from '../dto/date-query.dto';
+import { DateQueryDto, parseBucketMinutes } from '../dto/date-query.dto';
 import { StationDto } from '../dto/station.dto';
 import { MeasurementDto } from '../dto/measurement.dto';
 import {
@@ -92,6 +92,7 @@ export class StationsController {
     return await this.stationService.findMeasurementsBy(
       id,
       new Date(queryDto.date),
+      parseBucketMinutes(queryDto.bucketMinutes),
     );
   }
 

--- a/src/stations/database/model/station-measurement.entity.ts
+++ b/src/stations/database/model/station-measurement.entity.ts
@@ -36,3 +36,7 @@ export class StationMeasurementEntity {
 export const StationMeasurementEntitySchema = SchemaFactory.createForClass(
   StationMeasurementEntity,
 );
+
+// Indice para las consultas por estacion + dia (findMeasurementsByDay).
+// Sin el, cada consulta hace COLLSCAN de toda la coleccion.
+StationMeasurementEntitySchema.index({ stationId: 1, date: 1 });

--- a/src/stations/dto/date-query.dto.ts
+++ b/src/stations/dto/date-query.dto.ts
@@ -1,14 +1,33 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsNotEmpty } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDate, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class DateQueryDto {
   @ApiProperty()
   @IsDate()
   @IsNotEmpty()
   date: Date;
+
+  @ApiPropertyOptional({
+    description:
+      'Agrupacion del downsampling en minutos (1 punto por bucket). ' +
+      'Si no se indica, se devuelven todas las medidas del dia (sin agrupar). ' +
+      'Ej.: 10 para desktop, 20 para movil.',
+    example: 10,
+  })
+  @IsOptional()
+  bucketMinutes?: string;
 }
 
 export function toDate(value: string): Date {
   console.log(value);
   return new Date(value);
+}
+
+// Convierte el bucketMinutes recibido por query (string) en un entero seguro.
+// Ante valor ausente, no numerico o <= 0 devuelve el fallback (0 => sin agrupar,
+// se devuelve todo). Acota a 1 dia como maximo.
+export function parseBucketMinutes(value?: string, fallback = 0): number {
+  const n = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(n, 1440);
 }

--- a/src/stations/services/database/station-measurements.service.ts
+++ b/src/stations/services/database/station-measurements.service.ts
@@ -32,6 +32,7 @@ export class StationMeasurementsService {
   async findMeasurementsByDay(
     stationId: string,
     date: Date,
+    bucketMinutes = 0, // 0 => sin downsampling: devuelve todas las medidas del dia
   ): Promise<StationMeasurementEntity[]> {
     const startDate = new Date(date);
     startDate.setUTCHours(0, 0, 0, 0);
@@ -39,12 +40,39 @@ export class StationMeasurementsService {
     const endDate = new Date(startDate);
     endDate.setDate(startDate.getDate() + 1);
 
-    return this.stationMeasurementModel
+    const measurements = await this.stationMeasurementModel
       .find({
         stationId,
         date: { $gte: startDate, $lt: endDate },
       })
       .select('-_id -stationId')
+      .sort({ date: 1 })
       .lean();
+
+    return this.downsample(measurements, bucketMinutes);
+  }
+
+  // Conserva una medida por cada bucket de N minutos (la primera de cada bucket).
+  // Los datos historicos densos (p. ej. una medida cada pocos segundos) se
+  // devuelven ya aligerados, manteniendo intactos los documentos en la BD.
+  private downsample(
+    measurements: StationMeasurementEntity[],
+    bucketMinutes: number,
+  ): StationMeasurementEntity[] {
+    if (!bucketMinutes || bucketMinutes <= 0) return measurements;
+
+    const bucketMs = bucketMinutes * 60 * 1000;
+    const result: StationMeasurementEntity[] = [];
+    let lastBucket: number | null = null;
+
+    for (const m of measurements) {
+      const bucket = Math.floor(new Date(m.date).getTime() / bucketMs);
+      if (bucket !== lastBucket) {
+        result.push(m);
+        lastBucket = bucket;
+      }
+    }
+
+    return result;
   }
 }

--- a/src/stations/services/database/stations.service.ts
+++ b/src/stations/services/database/stations.service.ts
@@ -136,11 +136,13 @@ export class StationsService {
   async findMeasurementsBy(
     stationId: string,
     measurementDate: Date,
+    bucketMinutes?: number,
   ): Promise<MeasurementDto[]> {
     const measurements =
       await this.stationMeasurementsService.findMeasurementsByDay(
         stationId,
         measurementDate,
+        bucketMinutes,
       );
 
     return measurements.map((entity: StationMeasurementEntity) =>


### PR DESCRIPTION
Anade sobre main dos mejoras de rendimiento en las mediciones:

- **Indice** compuesto `{ stationId, date }` en `station_measurements` (evita COLLSCAN en las consultas por estacion y dia) + script `downsample-measurements.js` para adelgazar datos historicos densos.
- **Downsampling de la respuesta** por dia, configurable con el query param `bucketMinutes` (1 punto por bucket de N min); sin el parametro se devuelven todas las medidas (raw). Aligera payload y render del grafico sin borrar datos crudos.